### PR TITLE
search params fix for react-router-v4

### DIFF
--- a/server/express.js
+++ b/server/express.js
@@ -167,7 +167,7 @@ module.exports = (backend, appRoutes, error, options, cb) => {
 }
 
 function matchUrl (location, routes, cb) {
-  let matched = matchRoutes(routes, location)
+  let matched = matchRoutes(routes, location.split('?')[0])
   console.log('> match', routes, location)
   console.log('> matched', matched)
   if (matched && matched.length) {


### PR DESCRIPTION
This PR aims to fix search params support for this package.

Context: https://github.com/ReactTraining/react-router/issues/5132

As of now passing any kind of search param like 
``` /files?anything_at_all ``` is not supported in the matchRoutes function of react-router-config

Expected behaviour:
Display the page associated with /files 

Actual behaviour
404: Page not found.

This PR fixes this issue.